### PR TITLE
Update French

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -186,4 +186,8 @@
     <string name="new_temperament_requires_adapting_reference_note">L’ajustement de la note de référence est requis pour un nouveau tempérament\u00A0!</string>
     <string name="comma_separator">, </string>
     <string name="asharp_bflat_note_name">-</string>
+    <string name="capture">Enregistrer</string>
+    <string name="capture_duration">Durée d’enregistrement\u00A0: %d&#x200A;s</string>
+    <string name="no_capture_duration">Pas d’enregistrement</string>
+    <string name="capture_in_scientific_mode">Enregistrer en mode scientifique</string>
 </resources>


### PR DESCRIPTION
I was a bit puzzled by the English value for `no_capture_duration`, but looking at the German one, I decided to go with the meaning of "There is no capture, so no duration is available". I hope I wasn't too quick.