### PR TITLE
Add 1/5-comma meantone temperament

### DIFF
--- a/app/src/main/java/de/moekadu/tuner/temperaments/MusicalScaleFactory.kt
+++ b/app/src/main/java/de/moekadu/tuner/temperaments/MusicalScaleFactory.kt
@@ -47,6 +47,10 @@ class MusicalScaleFactory {
                     temperamentType, circleOfFifthsThirdCommaMeanTone,
                     noteNameScale, referenceNoteResolved, referenceFrequency, rootNoteResolved, frequencyMin, frequencyMax
                 )
+                TemperamentType.FifthCommaMeanTone -> MusicalScaleRatioBasedTemperaments(
+                    temperamentType, circleOfFifthsFifthCommaMeanTone,
+                    noteNameScale, referenceNoteResolved, referenceFrequency, rootNoteResolved, frequencyMin, frequencyMax
+                )
                 TemperamentType.WerckmeisterIII -> MusicalScaleRatioBasedTemperaments(
                     temperamentType, circleOfFifthsWerckmeisterIII,
                     noteNameScale, referenceNoteResolved, referenceFrequency, rootNoteResolved, frequencyMin, frequencyMax

--- a/app/src/main/java/de/moekadu/tuner/temperaments/NoteNameScaleFactory.kt
+++ b/app/src/main/java/de/moekadu/tuner/temperaments/NoteNameScaleFactory.kt
@@ -9,7 +9,7 @@ class NoteNameScaleFactory {
         fun getDefaultReferenceNote(temperamentType: TemperamentType): MusicalNote {
             return MusicalNote(BaseNote.A, NoteModifier.None, 4)
 //            return when (temperamentType) {
-//                TemperamentType.EDO12, TemperamentType.Pythagorean, TemperamentType.Pure, TemperamentType.QuarterCommaMeanTone, TemperamentType.ThirdCommaMeanTone, TemperamentType.WerckmeisterIII, TemperamentType.WerckmeisterIV, TemperamentType.WerckmeisterV, TemperamentType.WerckmeisterVI, TemperamentType.Kirnberger1, TemperamentType.Kirnberger2, TemperamentType.Kirnberger3, TemperamentType.Neidhardt1, TemperamentType.Neidhardt2, TemperamentType.Neidhardt3, TemperamentType.Valotti, TemperamentType.Young2, TemperamentType.EDO19, TemperamentType.EDO41, TemperamentType.Test -> {
+//                TemperamentType.EDO12, TemperamentType.Pythagorean, TemperamentType.Pure, TemperamentType.QuarterCommaMeanTone, TemperamentType.ThirdCommaMeanTone, TemperamentType.FifthCommaMeanTone, TemperamentType.WerckmeisterIII, TemperamentType.WerckmeisterIV, TemperamentType.WerckmeisterV, TemperamentType.WerckmeisterVI, TemperamentType.Kirnberger1, TemperamentType.Kirnberger2, TemperamentType.Kirnberger3, TemperamentType.Neidhardt1, TemperamentType.Neidhardt2, TemperamentType.Neidhardt3, TemperamentType.Valotti, TemperamentType.Young2, TemperamentType.EDO19, TemperamentType.EDO41, TemperamentType.Test -> {
 //                    MusicalNote(BaseNote.A, NoteModifier.None, 4)
 //                }
 //            }
@@ -21,7 +21,7 @@ class NoteNameScaleFactory {
         fun create(temperamentType: TemperamentType): NoteNameScale {
             val referenceNote = getDefaultReferenceNote(temperamentType)
             return when (temperamentType) {
-                TemperamentType.EDO12, TemperamentType.Pythagorean, TemperamentType.Pure, TemperamentType.QuarterCommaMeanTone, TemperamentType.ThirdCommaMeanTone, TemperamentType.WerckmeisterIII, TemperamentType.WerckmeisterIV, TemperamentType.WerckmeisterV, TemperamentType.WerckmeisterVI, TemperamentType.Kirnberger1, TemperamentType.Kirnberger2, TemperamentType.Kirnberger3, TemperamentType.Neidhardt1, TemperamentType.Neidhardt2, TemperamentType.Neidhardt3, TemperamentType.Valotti, TemperamentType.Young2, TemperamentType.Test -> {
+                TemperamentType.EDO12, TemperamentType.Pythagorean, TemperamentType.Pure, TemperamentType.QuarterCommaMeanTone, TemperamentType.ThirdCommaMeanTone, TemperamentType.FifthCommaMeanTone, TemperamentType.WerckmeisterIII, TemperamentType.WerckmeisterIV, TemperamentType.WerckmeisterV, TemperamentType.WerckmeisterVI, TemperamentType.Kirnberger1, TemperamentType.Kirnberger2, TemperamentType.Kirnberger3, TemperamentType.Neidhardt1, TemperamentType.Neidhardt2, TemperamentType.Neidhardt3, TemperamentType.Valotti, TemperamentType.Young2, TemperamentType.Test -> {
                     createNoteNameScale12Tone(referenceNote)
                 }
                 TemperamentType.ExtendedQuarterCommaMeanTone -> {

--- a/app/src/main/java/de/moekadu/tuner/temperaments/TemperamentCircleOfFifths.kt
+++ b/app/src/main/java/de/moekadu/tuner/temperaments/TemperamentCircleOfFifths.kt
@@ -62,6 +62,22 @@ val circleOfFifthsEDO12 = TemperamentCircleOfFifths(
     FC = FifthModification(pythagoreanComma = RationalNumber(-1, 12))
 )
 
+// quarter-comma meantone -> perfect major third
+val circleOfFifthsFifthCommaMeanTone = TemperamentCircleOfFifths(
+    CG = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    GD = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    DA = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    AE = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    EB = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    BFsharp = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    FsharpCsharp = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    CsharpGsharp = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    GsharpEflat = FifthModification(pythagoreanComma = RationalNumber(-1, 1), syntonicComma = RationalNumber(11, 5)),
+    EFlatBflat = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    BflatF = FifthModification(syntonicComma = RationalNumber(-1, 5)),
+    FC = FifthModification(syntonicComma = RationalNumber(-1, 5))
+)
+
 val circleOfFifthsWerckmeisterIII = TemperamentCircleOfFifths(
     CG = FifthModification(pythagoreanComma = RationalNumber(-1, 4)),
     GD = FifthModification(pythagoreanComma = RationalNumber(-1, 4)),

--- a/app/src/main/java/de/moekadu/tuner/temperaments/TemperamentType.kt
+++ b/app/src/main/java/de/moekadu/tuner/temperaments/TemperamentType.kt
@@ -9,6 +9,7 @@ enum class TemperamentType {
     QuarterCommaMeanTone,
     ExtendedQuarterCommaMeanTone,
     ThirdCommaMeanTone,
+    FifthCommaMeanTone,
     WerckmeisterIII,
     WerckmeisterIV,
     WerckmeisterV,
@@ -41,6 +42,7 @@ fun getTuningNameResourceId(temperamentType: TemperamentType) = when(temperament
     TemperamentType.QuarterCommaMeanTone -> R.string.quarter_comma_mean_tone
     TemperamentType.ExtendedQuarterCommaMeanTone -> R.string.extended_quarter_comma_mean_tone
     TemperamentType.ThirdCommaMeanTone -> R.string.third_comma_mean_tone
+    TemperamentType.FifthCommaMeanTone -> R.string.fifth_comma_mean_tone
     TemperamentType.WerckmeisterIII -> R.string.werckmeister_iii
     TemperamentType.WerckmeisterIV -> R.string.werckmeister_iv
     TemperamentType.WerckmeisterV -> R.string.werckmeister_v
@@ -72,6 +74,7 @@ fun getTuningDescriptionResourceId(temperamentType: TemperamentType) = when(temp
     TemperamentType.QuarterCommaMeanTone -> R.string.quarter_comma_mean_tone_desc
     TemperamentType.ExtendedQuarterCommaMeanTone -> R.string.extended_quarter_comma_mean_tone_desc
     TemperamentType.ThirdCommaMeanTone -> R.string.third_comma_mean_tone_desc
+    TemperamentType.FifthCommaMeanTone -> R.string.fifth_comma_mean_tone_desc
     TemperamentType.WerckmeisterIII -> R.string.werckmeister_iii_desc
     TemperamentType.WerckmeisterIV -> R.string.werckmeister_iv_desc
     TemperamentType.WerckmeisterV -> R.string.werckmeister_v_desc
@@ -103,6 +106,7 @@ fun getTuningNameAbbrResourceId(temperamentType: TemperamentType) = when(tempera
     TemperamentType.QuarterCommaMeanTone -> R.string.quarter_comma_mean_tone_abbr
     TemperamentType.ExtendedQuarterCommaMeanTone -> R.string.extended_quarter_comma_mean_tone_abbr
     TemperamentType.ThirdCommaMeanTone -> R.string.third_comma_mean_tone_abbr
+    TemperamentType.FifthCommaMeanTone -> R.string.fifth_comma_mean_tone_abbr
     TemperamentType.WerckmeisterIII -> R.string.werckmeister_iii_abbr
     TemperamentType.WerckmeisterIV -> R.string.werckmeister_iv_abbr
     TemperamentType.WerckmeisterV -> R.string.werckmeister_v_abbr

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,9 @@
     <string name="third_comma_mean_tone">⅓ comma meantone</string>
     <string name="third_comma_mean_tone_desc">Pure minor 3rds</string>
     <string name="third_comma_mean_tone_abbr">⅓ comma meantone</string>
+    <string name="fifth_comma_mean_tone">⅕ comma meantone</string>
+    <string name="fifth_comma_mean_tone_desc">Pure diatonic semitones</string>
+    <string name="fifth_comma_mean_tone_abbr">⅕ comma meantone</string>
     <string name="werckmeister_iii">Werckmeister III</string>
     <string name="werckmeister_iii_desc">¼ comma divisions</string>
     <string name="werckmeister_iii_abbr">Werckmeister III</string>

--- a/app/src/test/java/de/moekadu/tuner/TemperamentCircleOfFifthsTest.kt
+++ b/app/src/test/java/de/moekadu/tuner/TemperamentCircleOfFifthsTest.kt
@@ -29,6 +29,14 @@ class TemperamentCircleOfFifthsTest {
     }
 
     @Test
+    fun fifthCommaMeantone() {
+        val ratios = circleOfFifthsFifthCommaMeanTone.getRatios()
+        ratios.zip(notes).forEach { p ->
+            println("Fifth-comma mean tone: ${p.second}: ${cent(p.first)}")
+        }
+    }
+
+    @Test
     fun werckmeisterIII() {
         val ratios = circleOfFifthsWerckmeisterIII.getRatios()
         ratios.zip(notes).forEach { p ->


### PR DESCRIPTION
I don't exactly think I can make a great case that this *should* be included, so consider this more of a "pull offer".  I did code it up, so I figured it was worth sharing.

The maybe-not-great case: fifth-comma does show up in tuner apps and discussions on historical temperaments from time to time, it's a personal favorite on my hammered dulcimer, and apparently it's pretty good [for concertina](https://www.concertina.net/forums/index.php?/topic/21123-my-experience-with-15-comma-mean-tone-tuning/) as well.